### PR TITLE
renovate: update schedule to run every 3 months on the 25th

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -11,6 +11,9 @@
   "[markdown]": {
     "editor.defaultFormatter": "esbenp.prettier-vscode"
   },
+  "[shellscript]": {
+    "editor.defaultFormatter": "foxundermoon.shell-format"
+  },
   "[typescript]": {
     "editor.defaultFormatter": "esbenp.prettier-vscode"
   },

--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,5 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:base"],
-  "schedule": ["every 3 months on the first day of the month"]
+  "schedule": ["* * 25 */3 *"]
 }


### PR DESCRIPTION
This pull request includes a change to the `renovate.json` file to update the schedule configuration.

* [`renovate.json`](diffhunk://#diff-7b5c8955fc544a11b4b74eddb4115f9cc51c9cf162dbffa60d37eeed82a55a57L4-R4): Changed the schedule from "every 3 months on the first day of the month" to a cron expression that runs on the 25th day of every third month.