### PR TITLE
CI追加

### DIFF
--- a/.github/workflows/pnpm.yml
+++ b/.github/workflows/pnpm.yml
@@ -1,0 +1,25 @@
+# https://pnpm.io/continuous-integration#github-actions
+
+name: pnpm Example Workflow
+on:
+  push:
+
+jobs:
+  build:
+    runs-on: ubuntu-22.04
+    strategy:
+      matrix:
+        node-version: [20]
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: "pnpm"
+      - name: Install dependencies
+        run: pnpm install

--- a/.github/workflows/pnpm.yml
+++ b/.github/workflows/pnpm.yml
@@ -23,3 +23,8 @@ jobs:
           cache: "pnpm"
       - name: Install dependencies
         run: pnpm install
+
+      - name: Spell check
+        run: pnpm run cspell
+
+      - run: pnpm run prettier:check

--- a/.github/workflows/pnpm.yml
+++ b/.github/workflows/pnpm.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        node-version: [20]
+        node-version: [22]
     steps:
       - uses: actions/checkout@v4
       - name: Install pnpm
@@ -24,7 +24,6 @@ jobs:
       - name: Install dependencies
         run: pnpm install
 
-      - name: Spell check
-        run: pnpm run cspell
+      - run: pnpm run cspell
 
       - run: pnpm run prettier:check

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -7,7 +7,3 @@ if [ "$CURRENT_BRANCH" = "main" ]; then
     echo "main ブランチへの直コミットは禁止されています"
     exit 1
 fi
-
-pnpm run cspell
-pnpm run eslint
-pnpm run prettier:check

--- a/cspell.json
+++ b/cspell.json
@@ -1,5 +1,6 @@
 {
   "ignorePaths": ["pnpm-lock.yaml"],
+  "useGitignore": true,
   "words": [
     "iconify",
     "npmrc",

--- a/index.html
+++ b/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="ja">
   <head>
     <meta charset="UTF-8" />

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -8,7 +8,7 @@ import Header from "./Header";
 
 const normalizePaletteMode = (
   prefersDarkMode: boolean,
-  paletteMode?: string
+  paletteMode?: string,
 ): "light" | "dark" => {
   if (paletteMode === "light") return "light";
   if (paletteMode === "dark") return "dark";
@@ -21,7 +21,7 @@ const Layout = ({ children }: { children: ReactNode }) => {
     "light" | "dark"
   >("paletteMode");
   const [mode, setMode] = useState(
-    normalizePaletteMode(prefersDarkMode, paletteMode)
+    normalizePaletteMode(prefersDarkMode, paletteMode),
   );
   const colorMode = useMemo(
     () => ({
@@ -36,7 +36,7 @@ const Layout = ({ children }: { children: ReactNode }) => {
         removePaletteMode();
       },
     }),
-    []
+    [],
   );
   const theme = useMemo(
     () =>
@@ -45,7 +45,7 @@ const Layout = ({ children }: { children: ReactNode }) => {
           mode,
         },
       }),
-    [mode]
+    [mode],
   );
 
   return (

--- a/src/components/MaterialUISwitch.ts
+++ b/src/components/MaterialUISwitch.ts
@@ -15,7 +15,7 @@ const MaterialUISwitch = styled(Switch)(({ theme }) => ({
       transform: "translateX(22px)",
       "& .MuiSwitch-thumb:before": {
         backgroundImage: `url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" height="20" width="20" viewBox="0 0 20 20"><path fill="${encodeURIComponent(
-          "#fff"
+          "#fff",
         )}" d="M4.2 2.5l-.7 1.8-1.8.7 1.8.7.7 1.8.6-1.8L6.7 5l-1.9-.7-.6-1.8zm15 8.3a6.7 6.7 0 11-6.6-6.6 5.8 5.8 0 006.6 6.6z"/></svg>')`,
       },
       "& + .MuiSwitch-track": {
@@ -38,7 +38,7 @@ const MaterialUISwitch = styled(Switch)(({ theme }) => ({
       backgroundRepeat: "no-repeat",
       backgroundPosition: "center",
       backgroundImage: `url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" height="20" width="20" viewBox="0 0 20 20"><path fill="${encodeURIComponent(
-        "#fff"
+        "#fff",
       )}" d="M9.305 1.667V3.75h1.389V1.667h-1.39zm-4.707 1.95l-.982.982L5.09 6.072l.982-.982-1.473-1.473zm10.802 0L13.927 5.09l.982.982 1.473-1.473-.982-.982zM10 5.139a4.872 4.872 0 00-4.862 4.86A4.872 4.872 0 0010 14.862 4.872 4.872 0 0014.86 10 4.872 4.872 0 0010 5.139zm0 1.389A3.462 3.462 0 0113.471 10a3.462 3.462 0 01-3.473 3.472A3.462 3.462 0 016.527 10 3.462 3.462 0 0110 6.528zM1.665 9.305v1.39h2.083v-1.39H1.666zm14.583 0v1.39h2.084v-1.39h-2.084zM5.09 13.928L3.616 15.4l.982.982 1.473-1.473-.982-.982zm9.82 0l-.982.982 1.473 1.473.982-.982-1.473-1.473zM9.305 16.25v2.083h1.389V16.25h-1.39z"/></svg>')`,
     },
   },

--- a/src/components/Results.tsx
+++ b/src/components/Results.tsx
@@ -41,7 +41,7 @@ const Results = ({ searchQuery }: { searchQuery: string }) => {
           name={name}
           url={baseUrl.replace(
             "${searchQuery}",
-            encode === "SJIS" ? sjisEncode(searchQuery) : searchQuery
+            encode === "SJIS" ? sjisEncode(searchQuery) : searchQuery,
           )}
           showUrl={showUrl ?? true}
           icon={icon}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -5,7 +5,7 @@ import App from "./App";
 ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
   <React.StrictMode>
     <App />
-  </React.StrictMode>
+  </React.StrictMode>,
 );
 
-console.log("2025/01/04 b");
+console.log("2025/01/04 c");

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -7,3 +7,5 @@ ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
     <App />
   </React.StrictMode>
 );
+
+console.log("2025/01/04 a");

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -8,4 +8,4 @@ ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
   </React.StrictMode>
 );
 
-console.log("2025/01/04 a");
+console.log("2025/01/04 b");


### PR DESCRIPTION
This pull request includes several changes across different files to improve code quality and add a new GitHub Actions workflow for pnpm. The most important changes include adding a pnpm workflow, removing certain pre-commit hooks, and minor updates to various files.

### Workflow Addition:
* [`.github/workflows/pnpm.yml`](diffhunk://#diff-ac60990cd763580b6ef74ab431eb8f1234fc7d23b5617b1098f479442ef0c665R1-R29): Added a new GitHub Actions workflow for pnpm, including steps to install dependencies and run cspell and prettier checks.

### Pre-commit Hook Updates:
* [`.husky/pre-commit`](diffhunk://#diff-d2bc4bbf14eadc292d84e0ef5f7a93115c23557f533809fc80b896934291529dL10-L13): Removed `pnpm run cspell`, `pnpm run eslint`, and `pnpm run prettier:check` from the pre-commit hooks.

### Configuration Updates:
* [`cspell.json`](diffhunk://#diff-77519f787fe7e051a14c588f101d61e4d8f0d3b01bf8e16cb65d3838243d4e68R3): Added `useGitignore` to the configuration to respect `.gitignore` settings.

### Minor Code Fixes:
* [`index.html`](diffhunk://#diff-0eb547304658805aad788d320f10bf1f292797b5e6d745a3bf617584da017051L1-R1): Changed `<!DOCTYPE html>` to lowercase `<!doctype html>`.
* [`src/main.tsx`](diffhunk://#diff-1cd8b18798a1a103bfe13bef54354c1f3a3bea29a31c8eea1a0c67a3a839b811L8-R11): Added a trailing comma after `</React.StrictMode>` and a console log statement for debugging.

### Comma Addition for Consistency:
* `src/components/Layout.tsx`, `src/components/MaterialUISwitch.ts`, `src/components/Results.tsx`: Added trailing commas in various function calls and object definitions for consistency. [[1]](diffhunk://#diff-a4d72ac54801a218d7cfd27d169a7724d8c041bba5f6ba18e501670faab655a4L11-R11) [[2]](diffhunk://#diff-a4d72ac54801a218d7cfd27d169a7724d8c041bba5f6ba18e501670faab655a4L24-R24) [[3]](diffhunk://#diff-a4d72ac54801a218d7cfd27d169a7724d8c041bba5f6ba18e501670faab655a4L39-R39) [[4]](diffhunk://#diff-a4d72ac54801a218d7cfd27d169a7724d8c041bba5f6ba18e501670faab655a4L48-R48) [[5]](diffhunk://#diff-d4263fd486f921ef1460832163a0c78cf26893fb8accc11d52d50e233da7509dL18-R18) [[6]](diffhunk://#diff-d4263fd486f921ef1460832163a0c78cf26893fb8accc11d52d50e233da7509dL41-R41) [[7]](diffhunk://#diff-964fd6b6f94bce536dfa4fd3db941fec3b5c9f5caacb73c93ad7407d418c4176L44-R44)