### PR TITLE
husky v9 対応

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,9 +1,9 @@
-#!/usr/bin/env sh
-# shellcheck disable=SC1091
-. "$(dirname -- "$0")/_/husky.sh"
+# shellcheck disable=SC2148
 
 CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
+
 if [ "$CURRENT_BRANCH" = "main" ]; then
     echo "main ブランチへの直コミットは禁止されています"
+
     exit 1
 fi

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "eslint:fix": "eslint --ext .tsx,.ts . --fix",
     "prettier:check": "prettier --check .",
     "prettier:write": "prettier --write .",
-    "prepare": "husky install",
+    "prepare": "husky",
     "types:check": "tsc --noEmit --pretty"
   },
   "dependencies": {


### PR DESCRIPTION
This pull request includes changes to the pre-commit hook script and the `package.json` file to improve the development workflow.

Improvements to pre-commit hook:

* [`.husky/pre-commit`](diffhunk://#diff-d2bc4bbf14eadc292d84e0ef5f7a93115c23557f533809fc80b896934291529dL1-R7): Removed the shebang line and husky script inclusion, and added a shellcheck directive to disable SC2148.

Updates to `package.json`:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L18-R18): Modified the `prepare` script to simply run `husky` instead of `husky install`.